### PR TITLE
Add function of automatic updating

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -70,4 +70,5 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     })
   })
+  setInterval(reloadMessages, 5000);
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
 
   function buildHTML(message){
     var imagehtml = message.image.url == null ? "" : `<img src="${message.image.url}" class="lower-message__image">`
-    var html = `<div class="message" data-id="message.id">
+    var html = `<div class="message" data-message-id="${message.id}">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                      ${message.user_name}
@@ -22,29 +22,27 @@ $(function(){
   }
   
   var reloadMessages = function() {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
-    last_message_id = $('.message').last().data('message-id');
-    $.ajax({
-      //ルーティングで設定した通りのURLを指定
-      url: '/groups/:group_id/messages',
-      //ルーティングで設定した通りhttpメソッドをgetに指定
-      type: 'get',
-      dataType: 'json',
-      //dataオプションでリクエストに値を含める
-      data: {id: last_message_id}
-    })
-    .done(function(messages) {
-      var insertHTML = '';
-      data.forEach(function(message) {
-        insertHTML = buildHTML(message);
-        $('.messages').append(insertHTML);
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      last_message_id = $('.message:last').data('message-id');
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {last_id: last_message_id}
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        messages.forEach(function(message) {
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+        });
+      })
+      .fail(function() {
+        alert('自動更新に失敗しました');
       });
-    })
-    .fail(function() {
-      console.log('error');
-    });
-  };
-
+   };
+  }
 
   $('#new_message').on('submit',function(e){
     e.preventDefault();
@@ -70,5 +68,6 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     })
   })
+
   setInterval(reloadMessages, 5000);
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -34,14 +34,18 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      console.log('success');
+      var insertHTML = '';
+      data.forEach(function(message) {
+        insertHTML = buildHTML(message);
+        $('.messages').append(insertHTML);
+      });
     })
     .fail(function() {
       console.log('error');
     });
   };
 
-  
+
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
 
   function buildHTML(message){
     var imagehtml = message.image.url == null ? "" : `<img src="${message.image.url}" class="lower-message__image">`
-    var html = `<div class="message">
+    var html = `<div class="message" data-id="message.id">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                      ${message.user_name}
@@ -20,7 +20,28 @@ $(function(){
                 </div>`
     return html;
   }
+  
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    last_message_id = $('.message').last().data('message-id');
+    $.ajax({
+      //ルーティングで設定した通りのURLを指定
+      url: '/groups/:group_id/messages',
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log('success');
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
 
+  
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,19 +1,8 @@
 class Api::MessagesController < ApplicationController
+
   def index
-    @message = Message.new
-    @messages = @group.messages.includes(:user)
-    respond_to do |format|
-      format.html
-      format.json{ @new_messages = @messages.where('id > ?', params[:id]) }
+    @group = Group.find(params[:group_id]) 
+    @messages = @group.messages.includes(:user).where('id > ?', params[:last_id]) 
   end
 
-  private
-
-  def message_params
-    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
-  end
-
-  def set_group
-    @group = Group.find(params[:group_id])
-  end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,19 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json{ @new_messages = @messages.where('id > ?', params[:id]) }
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image
-  json.created_at message.created_at
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,5 @@
 
-.message
+.message{ :"data-message-id" => "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,4 @@
-json.content @message.content
+json.(@message, :content, :image)
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name
 json.id @message.id
-json.image @message.image

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,8 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# WHAT
自動更新機能の実装

# WHY
これまでの仕様では、
別ユーザーが別画面から投稿したメッセージはリロードしなければ表示されないため、
リアルタイムでのチャットにならない。
そのため、自動でチャット画面が更新される機能が必要。

＜動画キャプチャのリンク＞
https://gyazo.com/353870d2fbf3881887474641fd32effc